### PR TITLE
feat(rag): add query rewriting strategies (HyDE, Multi-Query, Step-Ba…

### DIFF
--- a/SimpleRAGEngine/components/rag_engine/langrag.py
+++ b/SimpleRAGEngine/components/rag_engine/langrag.py
@@ -12,6 +12,7 @@ from langbot_plugin.api.entities.builtin.rag import (
 )
 
 from .parser import FileParser
+from .query_rewrite import retrieve_with_rewrite
 from .strategies import get_strategy
 
 logger = logging.getLogger(__name__)
@@ -144,29 +145,50 @@ class LangRAG(RAGEngine):
         # Determine strategy for post-processing
         index_type = context.creation_settings.get("index_type") or "chunk"
         strategy = get_strategy(index_type)
-        logger.info(f"Retrieve: strategy={index_type}, top_k={top_k}")
+        logger.info(
+            f"Retrieve: strategy={index_type}, top_k={top_k}, "
+            f"query_rewrite={context.retrieval_settings.get('query_rewrite', 'off')}, "
+            f"query={query!r}"
+        )
 
         # For parent_child, over-fetch to allow dedup to still yield top_k results
         fetch_k = top_k * 3 if index_type == "parent_child" else top_k
 
-        # 1. Embed query (skip for pure full-text search)
-        query_vector: list[float] = []
-        if search_type != SearchType.FULL_TEXT:
-            embedding_model_uuid = context.creation_settings.get("embedding_model_uuid", "")
-            query_vectors = await self.plugin.invoke_embedding(embedding_model_uuid, [query])
-            query_vector = query_vectors[0]
+        # Check query rewrite settings
+        query_rewrite = context.retrieval_settings.get("query_rewrite", "off")
+        rewrite_llm = context.creation_settings.get("rewrite_llm_model_uuid", "")
 
-        # 2. Search
-        results = await self.plugin.vector_search(
-            collection_id=collection_id,
-            query_vector=query_vector,
-            top_k=fetch_k,
-            filters=context.filters or None,
-            search_type=search_type,
-            query_text=query,
-        )
+        if query_rewrite != "off" and rewrite_llm:
+            logger.info(f"Query rewrite enabled: strategy={query_rewrite}")
+            results = await retrieve_with_rewrite(
+                plugin=self.plugin,
+                query=query,
+                query_rewrite=query_rewrite,
+                rewrite_llm=rewrite_llm,
+                collection_id=collection_id,
+                embedding_model_uuid=context.creation_settings.get("embedding_model_uuid", ""),
+                fetch_k=fetch_k,
+                filters=context.filters or None,
+                search_type=search_type,
+            )
+        else:
+            # Original logic: embed query → vector_search
+            query_vector: list[float] = []
+            if search_type != SearchType.FULL_TEXT:
+                embedding_model_uuid = context.creation_settings.get("embedding_model_uuid", "")
+                query_vectors = await self.plugin.invoke_embedding(embedding_model_uuid, [query])
+                query_vector = query_vectors[0]
 
-        # 3. Post-process (strategy may deduplicate / re-rank)
+            results = await self.plugin.vector_search(
+                collection_id=collection_id,
+                query_vector=query_vector,
+                top_k=fetch_k,
+                filters=context.filters or None,
+                search_type=search_type,
+                query_text=query,
+            )
+
+        # Post-process (strategy may deduplicate / re-rank)
         raw_count = len(results)
         results = strategy.postprocess_results(results, top_k)
         logger.info(
@@ -174,7 +196,7 @@ class LangRAG(RAGEngine):
             f"(fetch_k={fetch_k})"
         )
 
-        # 4. Format results
+        # Format results
         entries: list[RetrievalResultEntry] = []
         for res in results:
             content_text = res.get("metadata", {}).get("text", "")

--- a/SimpleRAGEngine/components/rag_engine/langrag.yaml
+++ b/SimpleRAGEngine/components/rag_engine/langrag.yaml
@@ -73,6 +73,16 @@ spec:
       type: integer
       required: false
       default: 256
+    - name: rewrite_llm_model_uuid
+      label:
+        en_US: Query Rewrite LLM
+        zh_Hans: 查询重写 LLM
+      description:
+        en_US: LLM model for query rewriting (required when query rewriting is enabled)
+        zh_Hans: 用于查询重写的 LLM 模型（启用查询重写时需要）
+      type: llm-model-selector
+      required: false
+      default: ''
   retrieval_schema:
     - name: top_k
       label:
@@ -104,6 +114,25 @@ spec:
           label:
             en_US: Hybrid
             zh_Hans: 混合检索
+    - name: query_rewrite
+      label:
+        en_US: Query Rewriting
+        zh_Hans: 查询重写
+      description:
+        en_US: 'Off: direct search; HyDE: hypothetical document; Multi-Query: query expansion; Step-Back: abstract generalization'
+        zh_Hans: 'Off：直接检索；HyDE：假设文档嵌入；Multi-Query：多查询扩展；Step-Back：回退抽象提问'
+      type: select
+      required: false
+      default: "off"
+      options:
+        - name: "off"
+          label: { en_US: "Off", zh_Hans: "关闭" }
+        - name: hyde
+          label: { en_US: "HyDE", zh_Hans: "HyDE（假设文档）" }
+        - name: multi_query
+          label: { en_US: "Multi-Query", zh_Hans: "多查询扩展" }
+        - name: step_back
+          label: { en_US: "Step-Back", zh_Hans: "回退提问" }
 execution:
   python:
     path: langrag.py

--- a/SimpleRAGEngine/components/rag_engine/query_rewrite.py
+++ b/SimpleRAGEngine/components/rag_engine/query_rewrite.py
@@ -1,0 +1,203 @@
+"""Query rewriting strategies for retrieval augmentation.
+
+Provides HyDE, Multi-Query, and Step-Back rewriting to improve recall quality.
+Each strategy rewrites/expands the user query before embedding and searching.
+"""
+
+import logging
+
+from langbot_plugin.api.entities.builtin.provider.message import Message
+
+logger = logging.getLogger(__name__)
+
+MULTI_QUERY_COUNT = 3
+
+HYDE_PROMPT = """Please write a short passage that would answer the following question.
+Write as if you are writing a paragraph from a reference document.
+Do not say "I don't know" — just write a plausible answer.
+
+Question: {query}
+
+Passage:"""
+
+MULTI_QUERY_PROMPT = """Given the following user question, generate {n} different search queries
+that could help find relevant information. Each query should approach the question from a
+different angle or use different terminology.
+
+User question: {query}
+
+Output exactly {n} queries, one per line (no numbering, no bullets):"""
+
+STEP_BACK_PROMPT = """Given the following specific question, generate a more general/abstract
+question that would help retrieve broader background context.
+
+Specific question: {query}
+
+General question:"""
+
+
+def _extract_text(msg: Message) -> str:
+    """Extract plain text from an LLM response Message."""
+    if isinstance(msg.content, str):
+        return msg.content.strip()
+    if isinstance(msg.content, list):
+        return "".join(
+            e.text for e in msg.content if e.type == "text"
+        ).strip()
+    return ""
+
+
+async def retrieve_with_rewrite(
+    plugin,
+    query: str,
+    query_rewrite: str,
+    rewrite_llm: str,
+    collection_id: str,
+    embedding_model_uuid: str,
+    fetch_k: int,
+    filters,
+    search_type,
+) -> list[dict]:
+    """Route to the appropriate rewrite strategy and return raw search results."""
+    if query_rewrite == "hyde":
+        return await _retrieve_hyde(
+            plugin, query, rewrite_llm, collection_id, embedding_model_uuid,
+            fetch_k, filters, search_type,
+        )
+    elif query_rewrite == "multi_query":
+        return await _retrieve_multi_query(
+            plugin, query, rewrite_llm, collection_id, embedding_model_uuid,
+            fetch_k, filters, search_type,
+        )
+    elif query_rewrite == "step_back":
+        return await _retrieve_step_back(
+            plugin, query, rewrite_llm, collection_id, embedding_model_uuid,
+            fetch_k, filters, search_type,
+        )
+    else:
+        logger.warning(f"Unknown query_rewrite strategy: {query_rewrite}, falling back to direct search")
+        query_vectors = await plugin.invoke_embedding(embedding_model_uuid, [query])
+        return await plugin.vector_search(
+            collection_id=collection_id,
+            query_vector=query_vectors[0],
+            top_k=fetch_k,
+            filters=filters,
+            search_type=search_type,
+            query_text=query,
+        )
+
+
+async def _retrieve_hyde(
+    plugin, query, rewrite_llm, collection_id, embedding_model_uuid,
+    fetch_k, filters, search_type,
+) -> list[dict]:
+    """HyDE: generate a hypothetical document, embed it, and search with that vector."""
+    logger.info(f"[HyDE] Generating hypothetical document for query: {query!r}")
+    prompt = HYDE_PROMPT.format(query=query)
+    resp = await plugin.invoke_llm(rewrite_llm, [Message(role="user", content=prompt)])
+    hypothetical_doc = _extract_text(resp)
+    logger.info(f"[HyDE] Hypothetical document:\n{hypothetical_doc}")
+    logger.info("[HyDE] Embedding hypothetical document and searching...")
+
+    hyde_vectors = await plugin.invoke_embedding(embedding_model_uuid, [hypothetical_doc])
+    results = await plugin.vector_search(
+        collection_id=collection_id,
+        query_vector=hyde_vectors[0],
+        top_k=fetch_k,
+        filters=filters,
+        search_type=search_type,
+        query_text=query,
+    )
+    logger.info(f"[HyDE] Search returned {len(results)} results")
+    return results
+
+
+async def _retrieve_multi_query(
+    plugin, query, rewrite_llm, collection_id, embedding_model_uuid,
+    fetch_k, filters, search_type,
+) -> list[dict]:
+    """Multi-Query: generate N query variants, search with each, merge and deduplicate."""
+    logger.info(f"[Multi-Query] Generating {MULTI_QUERY_COUNT} sub-queries for: {query!r}")
+    prompt = MULTI_QUERY_PROMPT.format(query=query, n=MULTI_QUERY_COUNT)
+    resp = await plugin.invoke_llm(rewrite_llm, [Message(role="user", content=prompt)])
+    raw_text = _extract_text(resp)
+    sub_queries = [line.strip() for line in raw_text.splitlines() if line.strip()]
+    sub_queries = sub_queries[:MULTI_QUERY_COUNT]
+    logger.info("[Multi-Query] Generated sub-queries:")
+    for i, sq in enumerate(sub_queries):
+        logger.info(f"  [{i+1}] {sq}")
+
+    # Embed original query + sub-queries
+    all_queries = [query] + sub_queries
+    logger.info(f"[Multi-Query] Embedding {len(all_queries)} queries (1 original + {len(sub_queries)} generated)")
+    all_vectors = await plugin.invoke_embedding(embedding_model_uuid, all_queries)
+
+    # Search with each vector and merge results
+    seen_ids: set[str] = set()
+    merged: list[dict] = []
+    for i, vec in enumerate(all_vectors):
+        results = await plugin.vector_search(
+            collection_id=collection_id,
+            query_vector=vec,
+            top_k=fetch_k,
+            filters=filters,
+            search_type=search_type,
+            query_text=query,
+        )
+        new_count = sum(1 for r in results if r["id"] not in seen_ids)
+        logger.info(f"[Multi-Query] Query [{i}] returned {len(results)} results ({new_count} new)")
+        for r in results:
+            rid = r["id"]
+            if rid not in seen_ids:
+                seen_ids.add(rid)
+                merged.append(r)
+
+    # Sort by score descending and truncate to fetch_k
+    merged.sort(key=lambda r: r.get("score", 0), reverse=True)
+    merged = merged[:fetch_k]
+    logger.info(f"[Multi-Query] Merged: {len(seen_ids)} unique results, returning {len(merged)}")
+    return merged
+
+
+async def _retrieve_step_back(
+    plugin, query, rewrite_llm, collection_id, embedding_model_uuid,
+    fetch_k, filters, search_type,
+) -> list[dict]:
+    """Step-Back: generate a broader question, search with both original and abstract queries."""
+    logger.info(f"[Step-Back] Generating abstract question for: {query!r}")
+    prompt = STEP_BACK_PROMPT.format(query=query)
+    resp = await plugin.invoke_llm(rewrite_llm, [Message(role="user", content=prompt)])
+    abstract_query = _extract_text(resp)
+    logger.info(f"[Step-Back] Abstract query: {abstract_query!r}")
+
+    # Embed both original and abstract queries
+    logger.info("[Step-Back] Embedding original + abstract queries and searching...")
+    both_vectors = await plugin.invoke_embedding(
+        embedding_model_uuid, [query, abstract_query],
+    )
+
+    # Search with both vectors and merge
+    seen_ids: set[str] = set()
+    merged: list[dict] = []
+    for i, vec in enumerate(both_vectors):
+        label = "original" if i == 0 else "abstract"
+        results = await plugin.vector_search(
+            collection_id=collection_id,
+            query_vector=vec,
+            top_k=fetch_k,
+            filters=filters,
+            search_type=search_type,
+            query_text=query,
+        )
+        new_count = sum(1 for r in results if r["id"] not in seen_ids)
+        logger.info(f"[Step-Back] {label} query returned {len(results)} results ({new_count} new)")
+        for r in results:
+            rid = r["id"]
+            if rid not in seen_ids:
+                seen_ids.add(rid)
+                merged.append(r)
+
+    merged.sort(key=lambda r: r.get("score", 0), reverse=True)
+    merged = merged[:fetch_k]
+    logger.info(f"[Step-Back] Merged: {len(seen_ids)} unique results, returning {len(merged)}")
+    return merged


### PR DESCRIPTION
…ck) (#14)

Add query rewriting to SimpleRAGEngine to improve retrieval recall quality. Supports three strategies: HyDE (hypothetical document embedding), Multi-Query (query expansion with multiple variants), and Step-Back (abstract generalization). Rewriting logic is extracted into a separate query_rewrite module to keep langrag.py focused on the core flow.