### PR TITLE
feat: 支持可配置的混合检索融合权重

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 *.pyc
+.claude/
+.idea/
+claude/

--- a/LangRAG/components/knowledge_engine/langrag.py
+++ b/LangRAG/components/knowledge_engine/langrag.py
@@ -293,6 +293,9 @@ class LangRAG(KnowledgeEngine):
         collection_id = context.get_collection_id()
         search_type = context.retrieval_settings.get("search_type", SearchType.VECTOR)
 
+        # Read hybrid fusion weight (YAML default 0.7; vdb fallback handles None)
+        vector_weight = float(context.retrieval_settings.get("vector_weight", 0.7))
+
         # Determine strategy for post-processing
         index_type = context.creation_settings.get("index_type") or "chunk"
         strategy = get_strategy(index_type)
@@ -300,6 +303,10 @@ class LangRAG(KnowledgeEngine):
             f"Retrieve: strategy={index_type}, top_k={top_k}, "
             f"query_rewrite={context.retrieval_settings.get('query_rewrite', 'off')}, "
             f"query={query!r}"
+        )
+        logger.info(
+            f"Retrieve search config: search_type={search_type}, "
+            f"vector_weight={vector_weight}"
         )
 
         # For parent_child/qa, over-fetch to allow dedup to still yield top_k.
@@ -329,6 +336,7 @@ class LangRAG(KnowledgeEngine):
                 fetch_k=fetch_k,
                 filters=context.filters or None,
                 search_type=search_type,
+                vector_weight=vector_weight,
             )
         else:
             # Original logic: embed query → vector_search
@@ -349,6 +357,7 @@ class LangRAG(KnowledgeEngine):
                 filters=context.filters or None,
                 search_type=search_type,
                 query_text=query,
+                vector_weight=vector_weight,
             )
 
         # Post-process (strategy may deduplicate / re-rank)

--- a/LangRAG/components/knowledge_engine/langrag.yaml
+++ b/LangRAG/components/knowledge_engine/langrag.yaml
@@ -144,6 +144,20 @@ spec:
           label:
             en_US: Hybrid
             zh_Hans: 混合检索
+    - name: vector_weight
+      label:
+        en_US: Vector Search Weight
+        zh_Hans: 向量搜索权重
+      description:
+        en_US: 'Balance between vector and keyword search in hybrid mode (0.0 = keyword only, 1.0 = vector only)'
+        zh_Hans: '混合检索中向量搜索的权重（0.0 = 仅关键词，1.0 = 仅向量）'
+      type: float
+      required: false
+      default: 0.7
+      show_if:
+        field: search_type
+        operator: eq
+        value: hybrid
     - name: query_rewrite
       label:
         en_US: Query Rewriting

--- a/LangRAG/components/knowledge_engine/query_rewrite.py
+++ b/LangRAG/components/knowledge_engine/query_rewrite.py
@@ -68,6 +68,7 @@ async def retrieve_with_rewrite(
     fetch_k: int,
     filters,
     search_type,
+    vector_weight=None,
 ) -> list[dict]:
     """Route to the appropriate rewrite strategy and return raw search results."""
     if query_rewrite == "hyde":
@@ -80,6 +81,7 @@ async def retrieve_with_rewrite(
             fetch_k,
             filters,
             search_type,
+            vector_weight,
         )
     elif query_rewrite == "multi_query":
         return await _retrieve_multi_query(
@@ -91,6 +93,7 @@ async def retrieve_with_rewrite(
             fetch_k,
             filters,
             search_type,
+            vector_weight,
         )
     elif query_rewrite == "step_back":
         return await _retrieve_step_back(
@@ -102,6 +105,7 @@ async def retrieve_with_rewrite(
             fetch_k,
             filters,
             search_type,
+            vector_weight,
         )
     else:
         logger.warning(
@@ -115,6 +119,7 @@ async def retrieve_with_rewrite(
             filters=filters,
             search_type=search_type,
             query_text=query,
+            vector_weight=vector_weight,
         )
 
 
@@ -127,6 +132,7 @@ async def _retrieve_hyde(
     fetch_k,
     filters,
     search_type,
+    vector_weight=None,
 ) -> list[dict]:
     """HyDE: generate a hypothetical document, embed it, and search with that vector."""
     logger.info(f"[HyDE] Generating hypothetical document for query: {query!r}")
@@ -146,6 +152,7 @@ async def _retrieve_hyde(
         filters=filters,
         search_type=search_type,
         query_text=query,
+        vector_weight=vector_weight,
     )
     logger.info(f"[HyDE] Search returned {len(results)} results")
     return results
@@ -160,6 +167,7 @@ async def _retrieve_multi_query(
     fetch_k,
     filters,
     search_type,
+    vector_weight=None,
 ) -> list[dict]:
     """Multi-Query: generate N query variants, search with each, merge and deduplicate."""
     logger.info(
@@ -192,6 +200,7 @@ async def _retrieve_multi_query(
             filters=filters,
             search_type=search_type,
             query_text=query,
+            vector_weight=vector_weight,
         )
         new_count = sum(1 for r in results if r["id"] not in seen_ids)
         logger.info(
@@ -222,6 +231,7 @@ async def _retrieve_step_back(
     fetch_k,
     filters,
     search_type,
+    vector_weight=None,
 ) -> list[dict]:
     """Step-Back: generate a broader question, search with both original and abstract queries."""
     logger.info(f"[Step-Back] Generating abstract question for: {query!r}")
@@ -249,6 +259,7 @@ async def _retrieve_step_back(
             filters=filters,
             search_type=search_type,
             query_text=query,
+            vector_weight=vector_weight,
         )
         new_count = sum(1 for r in results if r["id"] not in seen_ids)
         logger.info(


### PR DESCRIPTION
## 变更说明
- 在 LangRAG 检索配置中暴露 vector_weight 参数
- 在 
etrieve 和 query rewrite 路径中透传 vector_weight
- 让混合检索权重可配置，默认对齐向量 0.7 / 全文 0.3
- 忽略本地开发辅助目录 .claude/、.idea/ 和 claude/

## 验证
- 已在 Chroma 后端验证 vector_weight 透传与融合日志
- 已在 SeekDB 后端验证 vector_weight 映射为 knn_boost/query_boost
- 已在关闭 rerank 的情况下验证纯 hybrid 融合检索成功返回结果